### PR TITLE
Add “Self-Supervised Learning of Structured Dynamics from Videos”

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Survey - https://dl.acm.org/doi/pdf/10.1145/3577925
 - [Surveys](#Surveys)
 - [Benchmarking](#Benchmarking)
 - [Representation Learning](#Representation-Learning)
+   - [2026](#2026)
    - [2025](#2025)
    - [2024](#2024)
    - [2023](#2023)
@@ -149,6 +150,11 @@ Fida Mohammad Thoker, Hazel Doughty, Piyush Bagad, Cees Snoek <br>
 # Representation Learning
 
 # *2026*
+
+- **Self-Supervised Learning of Structured Dynamics from Videos** (2026)<br>
+*arXiv preprint* <br>
+Lukas Knobel, Andrew Zisserman, Yuki M. Asano<br>
+[[Paper]](https://arxiv.org/abs/2607.21576)
 
 - **Depth-Wise Representation Development Under Blockwise Self-Supervised Learning for Video Vision Transformers** (2026)<br>
 *Arxiv 2026* <br>

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Fida Mohammad Thoker, Hazel Doughty, Piyush Bagad, Cees Snoek <br>
 - **Self-Supervised Learning of Structured Dynamics from Videos** (2026)<br>
 *arXiv preprint* <br>
 Lukas Knobel, Andrew Zisserman, Yuki M. Asano<br>
-[[Paper]](https://arxiv.org/abs/2607.21576)
+[[Paper]](https://arxiv.org/abs/2607.21576) [[Project Page]](https://lukasknobel.github.io/projects/StructuredDynamics/) [[Code]](https://github.com/lukasknobel/StructuredDynamics)
 
 - **Depth-Wise Representation Development Under Blockwise Self-Supervised Learning for Video Vision Transformers** (2026)<br>
 *Arxiv 2026* <br>


### PR DESCRIPTION
## Summary

Adds **"Self-Supervised Learning of Structured Dynamics from Videos"** to the **2026 Representation Learning** section.

The paper introduces the **Structured Dynamics Model (SDM)**, a self-supervised approach that learns structured video dynamics by explicitly disentangling dominant temporal changes from residual dynamics through future-feature prediction on frozen pretrained image transformer features. SDM is trained using unlabeled real videos together with weak supervision from synthetic Kubric data, enabling robust motion representations that separate camera-induced variation from meaningful object motion.

### Included Resources

- Paper
- Official project page
- Official code repository